### PR TITLE
stub: migrate to voxpupuli/puppet-unbound parameters

### DIFF
--- a/manifests/stub.pp
+++ b/manifests/stub.pp
@@ -34,8 +34,9 @@ define unbound::stub (
   $insecure      = false,
   $type          = 'transparent',
   $config_file   = $unbound::params::config_file,
-  $stub_first    = 'no',
+  $stub_first    = false,
   $stub_no_cache = 'no',
+  $no_cache      = false,
 ) {
 
   if ! $address {

--- a/templates/stub.erb
+++ b/templates/stub.erb
@@ -9,9 +9,9 @@ stub-zone:
   stub-addr: <%= addr %>
 <% end -%>
 <% end -%>
-<% if @stub_first == 'yes' -%>
+<% if @stub_first == 'yes' || @stub_first.to_s == 'true'-%>
   stub-first: yes
 <% end -%>
-<% if @stub_no_cache == 'yes' -%>
+<% if @stub_no_cache == 'yes' || @no_cache.to_s == 'true' -%>
   stub-no-cache: yes
 <% end -%>


### PR DESCRIPTION
Migrate to parameters used in voxpupuli/puppet-unbound unbound::stub so as we can employ the latter during our transition to Puppet 8.